### PR TITLE
Bump image tag version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ to a Kubernetes Cluster.
 | <a name="input_host_network"></a> [host\_network](#input\_host\_network) | Use Host Network for pod | `bool` | `false` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of IAM role for controller | `string` | `""` | no |
 | <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository on Dockerhub | `string` | `"amazon/aws-alb-ingress-controller"` | no |
-| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag | `string` | `"v2.4.3"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag | `string` | `"v2.5.3"` | no |
 | <a name="input_ingress_class"></a> [ingress\_class](#input\_ingress\_class) | The ingress class this controller will satisfy. If not specified, controller will match all ingresses without ingress class annotation and ingresses of type alb | `string` | `"alb"` | no |
 | <a name="input_ingress_max_concurrent_reconciles"></a> [ingress\_max\_concurrent\_reconciles](#input\_ingress\_max\_concurrent\_reconciles) | Maximum number of concurrently running reconcile loops for ingress (default 3) | `number` | `3` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Log level. Either `info` or `debug` | `string` | `"info"` | no |

--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -57,7 +57,7 @@ resources: ${resources}
   #   cpu: 100m
   #   memory: 128Mi
 
-# Leverage a PriorityClass to ensure the controller will survive resource shortages
+# priorityClassName specifies the PriorityClass to indicate the importance of controller pods
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 priorityClassName: ${priority_class_name}
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "prefer_ecr_repositories" {
 variable "image_tag" {
   description = "Image tag"
   type        = string
-  default     = "v2.4.3"
+  default     = "v2.5.3"
 }
 
 variable "name_override" {


### PR DESCRIPTION
Bumping controller's image tag version from v2.4.3 to v2.5.3 to fix a [bug](https://stackoverflow.com/questions/76035067/internal-error-occurred-failed-calling-webhook-mservice-elbv2-k8s-aws).

### Important Note
New fields `subnets`, `InboundCIDRs` and `SSLPolicy` added  in `IngressClassParams`. If upgrading from a previous version, you need to update the `IngressClassParams` CRD manually by running `kubectl apply -k "http://github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"` 

For more details refer [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.5.0)